### PR TITLE
Add TitleBar theming

### DIFF
--- a/themes/Voir-color-theme.json
+++ b/themes/Voir-color-theme.json
@@ -13,6 +13,11 @@
     "activityBarBadge.background": "#189edc",
     "sideBarTitle.foreground": "#bbbbbb",
 
+    "titleBar.activeBackground": "#050523",
+    "titleBar.activeForeground": "#ffffff",
+    "titleBar.inactiveBackground": "#050523",
+    "titleBar.inactiveForeground": "#56566b",
+
     "list.hoverBackground": "#ffffff05",
     "list.hoverForeground": "#ffffffee",
 


### PR DESCRIPTION
I added theming to the titlebar, so that it looks more clean. The default titlebar colors don't fit well with the theme.

Here's how it looked before:
![image](https://user-images.githubusercontent.com/45594986/71855775-a95ac480-30ea-11ea-9667-57d2b74c9d78.png)

And after theming the titlebar:
![image](https://user-images.githubusercontent.com/45594986/71855709-79abbc80-30ea-11ea-89bb-9318b638a229.png)
